### PR TITLE
Escape GITPATH to work with spaces in foldernames.

### DIFF
--- a/automated-wordpress-plugin-deployment/deploy.sh
+++ b/automated-wordpress-plugin-deployment/deploy.sh
@@ -22,9 +22,9 @@ echo
 
 # Check version in readme.txt is the same as plugin file after translating both to unix
 # line breaks to work around grep's failure to identify mac line breaks
-NEWVERSION1=`grep "^Stable tag:" $GITPATH/readme.txt | awk -F' ' '{print $NF}'`
+NEWVERSION1=`grep "^Stable tag:" "$GITPATH/readme.txt" | awk -F' ' '{print $NF}'`
 echo "readme.txt version: $NEWVERSION1"
-NEWVERSION2=`grep "Version: " $GITPATH/$MAINFILE | awk -F' ' '{print $NF}'`
+NEWVERSION2=`grep "Version: " "$GITPATH/$MAINFILE" | awk -F' ' '{print $NF}'`
 echo "$MAINFILE version: $NEWVERSION2"
 
 if [ "$NEWVERSION1" != "$NEWVERSION2" ]


### PR DESCRIPTION
Hallo Dominik,

als ich ein repo auf dem Cloud Drive liegen hatte, viel mir auf das das Script an der stelle nicht mit Verzeichnisnamen zurechtkommt, die ein Leerzeichen im Namen haben. 

Gruß
Frank

Signed-off-by: Frank Staude frank@staude.net
